### PR TITLE
Copy legacy github.com/shurcooL/go/vcs package and its users.

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,13 +37,16 @@ import (
 	"github.com/go-gl/glfw/v3.1/glfw"
 	"github.com/go-gl/mathgl/mgl64"
 	intmath "github.com/pkg/math"
+	"github.com/shurcooL/Conception-go/pkg/exp12"
+	"github.com/shurcooL/Conception-go/pkg/exp13"
+	"github.com/shurcooL/Conception-go/pkg/exp14"
+	. "github.com/shurcooL/Conception-go/pkg/gist7480523"
+	"github.com/shurcooL/Conception-go/pkg/legacyvcs"
+	"github.com/shurcooL/Conception-go/pkg/u6"
 	"github.com/shurcooL/go-goon"
 	"github.com/shurcooL/go-goon/bypass"
 	"github.com/shurcooL/go/analysis"
 	"github.com/shurcooL/go/exp/11"
-	"github.com/shurcooL/go/exp/12"
-	"github.com/shurcooL/go/exp/13"
-	"github.com/shurcooL/go/exp/14"
 	"github.com/shurcooL/go/gists/gist4727543"
 	. "github.com/shurcooL/go/gists/gist5423254"
 	"github.com/shurcooL/go/gists/gist5504644"
@@ -56,7 +59,6 @@ import (
 	. "github.com/shurcooL/go/gists/gist6445065"
 	"github.com/shurcooL/go/gists/gist6545684"
 	. "github.com/shurcooL/go/gists/gist7390843"
-	. "github.com/shurcooL/go/gists/gist7480523"
 	. "github.com/shurcooL/go/gists/gist7576154"
 	. "github.com/shurcooL/go/gists/gist7576804"
 	. "github.com/shurcooL/go/gists/gist7651991"
@@ -67,8 +69,6 @@ import (
 	"github.com/shurcooL/go/u/u10"
 	"github.com/shurcooL/go/u/u4"
 	"github.com/shurcooL/go/u/u5"
-	"github.com/shurcooL/go/u/u6"
-	"github.com/shurcooL/go/vcs"
 	"github.com/shurcooL/go/vfs_util"
 	"github.com/shurcooL/markdownfmt/markdown"
 	"golang.org/x/net/websocket"
@@ -7617,7 +7617,7 @@ func main() {
 					}
 
 					dir, file := filepath.Split(path)
-					if goPackage.Dir.Repo == nil || goPackage.Dir.Repo.Vcs.Type() != vcs.Git {
+					if goPackage.Dir.Repo == nil || goPackage.Dir.Repo.Vcs.Type() != legacyvcs.Git {
 						return
 					}
 
@@ -7755,7 +7755,7 @@ func main() {
 					}
 
 					dir, file := filepath.Split(path)
-					if goPackage.Dir.Repo == nil || goPackage.Dir.Repo.Vcs.Type() != vcs.Git {
+					if goPackage.Dir.Repo == nil || goPackage.Dir.Repo.Vcs.Type() != legacyvcs.Git {
 						return
 					}
 

--- a/pkg/exp12/main.go
+++ b/pkg/exp12/main.go
@@ -4,9 +4,9 @@ package exp12
 import (
 	"sync"
 
-	"github.com/shurcooL/go/exp/13"
+	"github.com/shurcooL/Conception-go/pkg/exp13"
+	"github.com/shurcooL/Conception-go/pkg/legacyvcs"
 	"github.com/shurcooL/go/gists/gist7802150"
-	"github.com/shurcooL/go/vcs"
 )
 
 // rootPath -> *VcsState
@@ -26,7 +26,7 @@ type Directory struct {
 }
 
 func (this *Directory) Update() {
-	if vcs := vcs.New(this.path); vcs != nil {
+	if vcs := legacyvcs.New(this.path); vcs != nil {
 		reposLock.Lock()
 		if repo, ok := repos[vcs.RootPath()]; ok {
 			this.Repo = repo

--- a/pkg/exp12/main.go
+++ b/pkg/exp12/main.go
@@ -1,0 +1,58 @@
+// Package exp12 provides caching of vcs per directory.
+package exp12
+
+import (
+	"sync"
+
+	"github.com/shurcooL/go/exp/13"
+	"github.com/shurcooL/go/gists/gist7802150"
+	"github.com/shurcooL/go/vcs"
+)
+
+// rootPath -> *VcsState
+var repos = make(map[string]*exp13.VcsState)
+var reposLock sync.Mutex
+
+// path -> *Directory
+var directories = make(map[string]*Directory)
+var directoriesLock sync.Mutex
+
+type Directory struct {
+	path string
+
+	Repo *exp13.VcsState // nil if no Vcs.
+
+	gist7802150.DepNode2
+}
+
+func (this *Directory) Update() {
+	if vcs := vcs.New(this.path); vcs != nil {
+		reposLock.Lock()
+		if repo, ok := repos[vcs.RootPath()]; ok {
+			this.Repo = repo
+		} else {
+			this.Repo = exp13.NewVcsState(vcs)
+			repos[vcs.RootPath()] = this.Repo
+		}
+		reposLock.Unlock()
+	}
+}
+
+func newDirectory(path string) *Directory {
+	this := &Directory{path: path}
+	// No DepNode2I sources, so each instance can only be updated (i.e. initialized) once.
+	return this
+}
+
+// LookupDirectory is safe to call concurrently.
+func LookupDirectory(path string) *Directory {
+	directoriesLock.Lock()
+	defer directoriesLock.Unlock()
+	if dir := directories[path]; dir != nil {
+		return dir
+	} else {
+		dir = newDirectory(path)
+		directories[path] = dir
+		return dir
+	}
+}

--- a/pkg/exp13/main.go
+++ b/pkg/exp13/main.go
@@ -1,0 +1,85 @@
+// Package exp13 offers caching of vcs state per repository.
+package exp13
+
+import (
+	"github.com/shurcooL/go/gists/gist7802150"
+	"github.com/shurcooL/go/vcs"
+	go_vcs "golang.org/x/tools/go/vcs"
+)
+
+type VcsState struct {
+	Vcs vcs.Vcs
+
+	VcsLocal  *VcsLocal
+	VcsRemote *VcsRemote
+
+	RepoRoot *go_vcs.RepoRoot
+
+	// THINK: No need to add repo as a DepNode2I, just add it a plain variable. Maybe?
+	// TODO: No need for this to have a DepNode2Manual, remove it.
+	//       Well, the idea is I don't foresee anyone invalidating the entire VcsState.
+	gist7802150.DepNode2Manual
+}
+
+func NewVcsState(vcs vcs.Vcs) *VcsState {
+	this := &VcsState{
+		Vcs: vcs,
+	}
+	this.VcsLocal = NewVcsLocal(this)
+	this.VcsRemote = NewVcsRemote(this)
+	return this
+}
+
+// ---
+
+type VcsLocal struct {
+	Status      string
+	Stash       string
+	Remote      string
+	LocalBranch string
+	LocalRev    string
+
+	gist7802150.DepNode2
+}
+
+func NewVcsLocal(repo *VcsState) *VcsLocal {
+	this := &VcsLocal{}
+	// THINK: No need to add repo as a DepNode2I, just add it a plain variable. Maybe?
+	this.AddSources(repo, &gist7802150.DepNode2Manual{})
+	return this
+}
+
+func (this *VcsLocal) Update() {
+	// THINK: No need to add repo as a DepNode2I, just add it a plain variable. Maybe?
+	vcs := this.GetSources()[0].(*VcsState).Vcs
+
+	this.Status = vcs.GetStatus()
+	this.Stash = vcs.GetStash()
+	this.Remote = vcs.GetRemote()
+	this.LocalBranch = vcs.GetLocalBranch()
+	this.LocalRev = vcs.GetLocalRev()
+}
+
+// ---
+
+type VcsRemote struct {
+	RemoteRev   string
+	IsContained bool // True if remote commit is contained in the default local branch.
+
+	gist7802150.DepNode2
+}
+
+func NewVcsRemote(repo *VcsState) *VcsRemote {
+	this := &VcsRemote{}
+	this.AddSources(repo)
+	return this
+}
+
+func (this *VcsRemote) Update() {
+	vcs := this.GetSources()[0].(*VcsState).Vcs
+
+	this.RemoteRev = vcs.GetRemoteRev()
+	if this.RemoteRev != "" {
+		this.IsContained = vcs.IsContained(this.RemoteRev)
+	}
+}

--- a/pkg/exp13/main.go
+++ b/pkg/exp13/main.go
@@ -2,13 +2,13 @@
 package exp13
 
 import (
+	"github.com/shurcooL/Conception-go/pkg/legacyvcs"
 	"github.com/shurcooL/go/gists/gist7802150"
-	"github.com/shurcooL/go/vcs"
 	go_vcs "golang.org/x/tools/go/vcs"
 )
 
 type VcsState struct {
-	Vcs vcs.Vcs
+	Vcs legacyvcs.Vcs
 
 	VcsLocal  *VcsLocal
 	VcsRemote *VcsRemote
@@ -21,7 +21,7 @@ type VcsState struct {
 	gist7802150.DepNode2Manual
 }
 
-func NewVcsState(vcs vcs.Vcs) *VcsState {
+func NewVcsState(vcs legacyvcs.Vcs) *VcsState {
 	this := &VcsState{
 		Vcs: vcs,
 	}

--- a/pkg/exp14/main.go
+++ b/pkg/exp14/main.go
@@ -1,0 +1,94 @@
+// Package exp14 provides caching of a list of Go packages.
+package exp14
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/shurcooL/go/gists/gist7480523"
+	"github.com/shurcooL/go/gists/gist7651991"
+	"github.com/shurcooL/go/gists/gist7802150"
+	"github.com/shurcooL/go/gists/gist8018045"
+)
+
+type GoPackageList interface {
+	List() []*gist7480523.GoPackage
+
+	gist7802150.DepNode2I
+}
+
+// GoPackages is a cached list of all Go packages in GOPATH including/excluding GOROOT.
+type GoPackages struct {
+	SkipGoroot bool // Currently, works on initial run only; changing its value afterwards has no effect.
+
+	Entries []*gist7480523.GoPackage
+
+	gist7802150.DepNode2
+}
+
+func (this *GoPackages) Update() {
+	// TODO: Have a source?
+
+	started := time.Now()
+	defer func() {
+		fmt.Printf("GoPackages.Update: %v ms; %v packages.\n", time.Since(started).Seconds()*1000, len(this.Entries))
+	}()
+
+	// TODO: Make it load in background, without blocking, etc.
+	{
+		goPackages := make(chan *gist7480523.GoPackage, 64)
+
+		if this.SkipGoroot {
+			go gist8018045.GetGopathGoPackages(goPackages)
+		} else {
+			go gist8018045.GetGoPackages(goPackages)
+		}
+
+		this.Entries = nil
+		for {
+			if goPackage, ok := <-goPackages; ok {
+				this.Entries = append(this.Entries, goPackage)
+			} else {
+				break
+			}
+		}
+	}
+}
+
+func (this *GoPackages) List() []*gist7480523.GoPackage {
+	return this.Entries
+}
+
+// GoPackagesFromReader is a cached list of Go packages specified by newline separated import paths from Reader.
+type GoPackagesFromReader struct {
+	Reader io.Reader
+
+	Entries []*gist7480523.GoPackage
+
+	gist7802150.DepNode2
+}
+
+func (this *GoPackagesFromReader) Update() {
+	reduceFunc := func(importPath string) interface{} {
+		if goPackage := gist7480523.GoPackageFromImportPath(importPath); goPackage != nil {
+			return goPackage
+		}
+		return nil
+	}
+
+	goPackages := gist7651991.GoReduceLinesFromReader(this.Reader, 8, reduceFunc)
+
+	this.Entries = nil
+	for {
+		if goPackage, ok := <-goPackages; ok {
+			this.Entries = append(this.Entries, goPackage.(*gist7480523.GoPackage))
+		} else {
+			break
+		}
+	}
+}
+
+func (this *GoPackagesFromReader) List() []*gist7480523.GoPackage {
+	return this.Entries
+}

--- a/pkg/exp14/main.go
+++ b/pkg/exp14/main.go
@@ -6,10 +6,10 @@ import (
 	"io"
 	"time"
 
-	"github.com/shurcooL/go/gists/gist7480523"
+	"github.com/shurcooL/Conception-go/pkg/gist7480523"
+	"github.com/shurcooL/Conception-go/pkg/gist8018045"
 	"github.com/shurcooL/go/gists/gist7651991"
 	"github.com/shurcooL/go/gists/gist7802150"
-	"github.com/shurcooL/go/gists/gist8018045"
 )
 
 type GoPackageList interface {

--- a/pkg/gist7480523/import_path_found.go
+++ b/pkg/gist7480523/import_path_found.go
@@ -1,0 +1,30 @@
+package gist7480523
+
+import (
+	"path/filepath"
+)
+
+// An ImportPathFound describes the Import Path found in a GOPATH workspace.
+type ImportPathFound struct {
+	importPath  string
+	gopathEntry string
+}
+
+func NewImportPathFound(importPath, gopathEntry string) ImportPathFound {
+	return ImportPathFound{
+		importPath:  importPath,
+		gopathEntry: gopathEntry,
+	}
+}
+
+func (w *ImportPathFound) ImportPath() string {
+	return w.importPath
+}
+
+func (w *ImportPathFound) GopathEntry() string {
+	return w.gopathEntry
+}
+
+func (w *ImportPathFound) FullPath() string {
+	return filepath.Join(w.gopathEntry, "src", w.importPath)
+}

--- a/pkg/gist7480523/main.go
+++ b/pkg/gist7480523/main.go
@@ -1,0 +1,181 @@
+// Package gist7480523 contains types and funcs for dealing with instances of a Go package found in a directory,
+// including caching of its directory entry, vcs repository, and vcs state.
+package gist7480523
+
+import (
+	"fmt"
+	"go/build"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/shurcooL/go/exp/12"
+	"golang.org/x/tools/go/vcs"
+
+	"github.com/shurcooL/go/gists/gist5504644"
+	"github.com/shurcooL/go/gists/gist7802150"
+)
+
+type GoPackageStringer func(*GoPackage) string
+
+// A GoPackage describes a single package found in a directory.
+// This is partially a copy of "cmd/go".Package, except it can be imported and reused.
+// https://code.google.com/p/go/source/browse/src/cmd/go/pkg.go?name=release#24
+type GoPackage struct {
+	Bpkg    *build.Package // Bpkg is not nil.
+	BpkgErr error
+
+	Dir *exp12.Directory
+}
+
+func GoPackageFromImportPathFound(importPathFound ImportPathFound) *GoPackage {
+	bpkg, err := gist5504644.BuildPackageFromSrcDir(importPathFound.FullPath())
+	return goPackageFromBuildPackage(bpkg, err)
+}
+
+func GoPackageFromImportPath(importPath string) *GoPackage {
+	bpkg, err := gist5504644.BuildPackageFromImportPath(importPath)
+	return goPackageFromBuildPackage(bpkg, err)
+}
+
+func GoPackageFromPath(path, srcDir string) (*GoPackage, error) {
+	bpkg, err := gist5504644.BuildPackageFromPath(path, srcDir)
+	if err != nil {
+		if _, noGo := err.(*build.NoGoError); noGo || bpkg.Dir == "" {
+			return nil, err
+		}
+	}
+	return goPackageFromBuildPackage(bpkg, err), nil
+}
+
+func goPackageFromBuildPackage(bpkg *build.Package, bpkgErr error) *GoPackage {
+	if bpkgErr != nil {
+		if _, noGo := bpkgErr.(*build.NoGoError); noGo || bpkg.Dir == "" {
+			return nil
+		}
+	}
+
+	if bpkg.ConflictDir != "" {
+		fmt.Fprintf(os.Stderr, "warning: ConflictDir=%q (Dir=%q)\n", bpkg.ConflictDir, bpkg.Dir)
+		return nil
+	}
+
+	goPackage := &GoPackage{
+		Bpkg:    bpkg,
+		BpkgErr: bpkgErr,
+
+		Dir: exp12.LookupDirectory(bpkg.Dir),
+	}
+
+	/*if goPackage.Bpkg.Goroot == false { // Optimization that assume packages under Goroot are not under vcs
+		// TODO: markAsNotNeedToUpdate() because of external insight?
+	}*/
+
+	return goPackage
+}
+
+// This is okay to call concurrently (a mutex is used internally).
+// Actually, not completely okay because MakeUpdated technology is not thread-safe.
+func (this *GoPackage) UpdateVcs() {
+	if this.Bpkg.Goroot == false { // Optimization that assume packages under Goroot are not under vcs
+		gist7802150.MakeUpdated(this.Dir)
+	}
+}
+
+func (this *GoPackage) UpdateVcsFields() {
+	if this.Dir.Repo == nil {
+		return
+	}
+
+	gist7802150.MakeUpdated(this.Dir.Repo.VcsLocal)
+	gist7802150.MakeUpdated(this.Dir.Repo.VcsRemote)
+
+	repoImportPath := GetRepoImportPath(this.Dir.Repo.Vcs.RootPath(), this.Bpkg.SrcRoot)
+	if repoRoot, err := vcs.RepoRootForImportPath(repoImportPath, false); err == nil {
+		this.Dir.Repo.RepoRoot = repoRoot
+	}
+}
+
+// GetRepoImportPath figures out the repo root import path given repoPath and srcRoot.
+// It handles symlinks that may be involved in the paths.
+// It also handles a possible case mismatch in the prefix, printing a warning to stderr if detected.
+func GetRepoImportPath(repoPath, srcRoot string) string {
+	if s, err := filepath.EvalSymlinks(repoPath); err == nil {
+		repoPath = s
+	} else {
+		fmt.Fprintln(os.Stderr, "warning: GetRepoImportPath: can't resolve symlink:", err)
+	}
+	if s, err := filepath.EvalSymlinks(srcRoot); err == nil {
+		srcRoot = s
+	} else {
+		fmt.Fprintln(os.Stderr, "warning: GetRepoImportPath: can't resolve symlink:", err)
+	}
+
+	sep := string(filepath.Separator)
+
+	// Detect and handle case mismatch in prefix.
+	if prefixLen := len(srcRoot + sep); len(repoPath) >= prefixLen && srcRoot+sep != repoPath[:prefixLen] && strings.EqualFold(srcRoot+sep, repoPath[:prefixLen]) {
+		fmt.Fprintln(os.Stderr, "warning: GetRepoImportPath: prefix case doesn't match:", srcRoot+sep, repoPath[:prefixLen])
+		return filepath.ToSlash(repoPath[prefixLen:])
+	}
+
+	return filepath.ToSlash(strings.TrimPrefix(repoPath, srcRoot+sep))
+}
+func GetRepoImportPathPattern(repoPath, srcRoot string) string {
+	return GetRepoImportPath(repoPath, srcRoot) + "/..."
+}
+
+func (this *GoPackage) String() string {
+	return this.Bpkg.ImportPath
+}
+
+// byImportPath implements sort.Interface for sorting Go packages by their import path.
+type byImportPath []*GoPackage
+
+func (v byImportPath) Len() int           { return len(v) }
+func (v byImportPath) Less(i, j int) bool { return v[i].Bpkg.ImportPath < v[j].Bpkg.ImportPath }
+func (v byImportPath) Swap(i, j int)      { v[i], v[j] = v[j], v[i] }
+
+// =====
+
+// GoPackageRepo represents a collection of Go packages contained by one VCS repository.
+type GoPackageRepo struct {
+	rootPath   string
+	goPackages []*GoPackage
+}
+
+// NewGoPackageRepo sorts goPackages by import path and returns a GoPackageRepo.
+func NewGoPackageRepo(rootPath string, goPackages []*GoPackage) GoPackageRepo {
+	sort.Sort(byImportPath(goPackages))
+	return GoPackageRepo{rootPath, goPackages}
+}
+
+// RepoImportPath returns what would be the import path of the root folder of the repository. It may or may not
+// be an actual Go package. E.g.,
+//
+//	"github.com/owner/repo"
+func (repo GoPackageRepo) RepoImportPath() string {
+	return GetRepoImportPath(repo.rootPath, repo.goPackages[0].Bpkg.SrcRoot)
+}
+
+// ImportPathPattern returns an import path pattern that matches all of the Go packages in this repo.
+// E.g.,
+//
+//	"github.com/owner/repo/..."
+func (repo GoPackageRepo) ImportPathPattern() string {
+	return GetRepoImportPathPattern(repo.rootPath, repo.goPackages[0].Bpkg.SrcRoot)
+}
+
+// RootPath returns the path to the root workdir folder of the repository.
+func (repo GoPackageRepo) RootPath() string         { return repo.rootPath }
+func (repo GoPackageRepo) GoPackages() []*GoPackage { return repo.goPackages }
+
+// ImportPaths returns a newline separated list of all import paths.
+func (repo GoPackageRepo) ImportPaths() string {
+	var importPaths []string
+	for _, goPackage := range repo.goPackages {
+		importPaths = append(importPaths, goPackage.Bpkg.ImportPath)
+	}
+	return strings.Join(importPaths, "\n")
+}

--- a/pkg/gist7480523/main.go
+++ b/pkg/gist7480523/main.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/shurcooL/go/exp/12"
+	"github.com/shurcooL/Conception-go/pkg/exp12"
 	"golang.org/x/tools/go/vcs"
 
 	"github.com/shurcooL/go/gists/gist5504644"

--- a/pkg/gist7480523/main_test.go
+++ b/pkg/gist7480523/main_test.go
@@ -1,0 +1,16 @@
+package gist7480523_test
+
+import (
+	"fmt"
+
+	"github.com/shurcooL/go/gists/gist7480523"
+)
+
+func ExampleGetRepoImportPathPattern() {
+	fmt.Println(gist7480523.GetRepoImportPathPattern("/home/User/Go/src/github.com/owner/repo", "/home/User/Go/src"))
+	fmt.Println(gist7480523.GetRepoImportPathPattern("/home/user/go/src/github.com/owner/repo", "/home/User/Go/src"))
+
+	// Output:
+	// github.com/owner/repo/...
+	// github.com/owner/repo/...
+}

--- a/pkg/gist7480523/main_test.go
+++ b/pkg/gist7480523/main_test.go
@@ -3,7 +3,7 @@ package gist7480523_test
 import (
 	"fmt"
 
-	"github.com/shurcooL/go/gists/gist7480523"
+	"github.com/shurcooL/Conception-go/pkg/gist7480523"
 )
 
 func ExampleGetRepoImportPathPattern() {

--- a/pkg/gist8018045/main.go
+++ b/pkg/gist8018045/main.go
@@ -1,0 +1,175 @@
+// Package gist8018045 provides funcs to get a list of all local Go packages in GOPATH workspaces and GOROOT.
+package gist8018045
+
+import (
+	"go/build"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/shurcooL/go/gists/gist5504644"
+	"github.com/shurcooL/go/gists/gist7480523"
+)
+
+// GetGoPackages gets all local Go packages (from GOROOT and all GOPATH workspaces).
+func GetGoPackages(out chan<- *gist7480523.GoPackage) {
+	for _, root := range build.Default.SrcDirs() {
+		_ = filepath.Walk(root, func(path string, fi os.FileInfo, err error) error {
+			if err != nil {
+				log.Printf("can't stat file %s: %v\n", path, err)
+				return nil
+			}
+			switch {
+			case !fi.IsDir():
+				return nil
+			case path == root:
+				return nil
+			case strings.HasPrefix(fi.Name(), ".") || strings.HasPrefix(fi.Name(), "_") || fi.Name() == "testdata":
+				return filepath.SkipDir
+			default:
+				importPath, err := filepath.Rel(root, path)
+				if err != nil {
+					return nil
+				}
+				// Prune search if we encounter any of these import paths.
+				switch importPath {
+				case "builtin":
+					return nil
+				}
+				if goPackage := gist7480523.GoPackageFromImportPath(importPath); goPackage != nil {
+					out <- goPackage
+				}
+				return nil
+			}
+		})
+	}
+	close(out)
+}
+
+// GetGopathGoPackages gets Go packages in all GOPATH workspaces.
+func GetGopathGoPackages(out chan<- *gist7480523.GoPackage) {
+	gopathEntries := filepath.SplitList(build.Default.GOPATH)
+	for _, gopathEntry := range gopathEntries {
+		root := filepath.Join(gopathEntry, "src")
+		if !isDir(root) {
+			continue
+		}
+		_ = filepath.Walk(root, func(path string, fi os.FileInfo, err error) error {
+			if err != nil {
+				log.Printf("can't stat file %s: %v\n", path, err)
+				return nil
+			}
+			if !fi.IsDir() {
+				return nil
+			}
+			if strings.HasPrefix(fi.Name(), ".") || strings.HasPrefix(fi.Name(), "_") || fi.Name() == "testdata" {
+				return filepath.SkipDir
+			}
+			importPath, err := filepath.Rel(root, path)
+			if err != nil {
+				return nil
+			}
+			importPathFound := gist7480523.NewImportPathFound(importPath, gopathEntry)
+			if goPackage := gist7480523.GoPackageFromImportPathFound(importPathFound); goPackage != nil {
+				out <- goPackage
+			}
+			return nil
+		})
+	}
+	close(out)
+}
+
+func isDir(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi.IsDir()
+}
+
+// rec is the recursive body of getGoPackagesA.
+func rec(out chan<- gist7480523.ImportPathFound, importPathFound gist7480523.ImportPathFound) {
+	if goPackage := gist7480523.GoPackageFromImportPathFound(importPathFound); goPackage != nil {
+		out <- importPathFound
+	}
+
+	entries, err := ioutil.ReadDir(importPathFound.FullPath())
+	if err == nil {
+		for _, v := range entries {
+			if v.IsDir() && !strings.HasPrefix(v.Name(), ".") && !strings.HasPrefix(v.Name(), "_") || v.Name() == "testdata" {
+				rec(out, gist7480523.NewImportPathFound(filepath.Join(importPathFound.ImportPath(), v.Name()), importPathFound.GopathEntry()))
+			}
+		}
+	}
+}
+
+func getGoPackagesA(out chan<- gist7480523.ImportPathFound) {
+	gopathEntries := filepath.SplitList(build.Default.GOPATH)
+	for _, gopathEntry := range gopathEntries {
+		rec(out, gist7480523.NewImportPathFound(".", gopathEntry))
+	}
+	close(out)
+}
+
+func getGoPackagesB(out chan<- gist7480523.ImportPathFound) {
+	gopathEntries := filepath.SplitList(build.Default.GOPATH)
+	for _, gopathEntry := range gopathEntries {
+		root := filepath.Join(gopathEntry, "src")
+		if !isDir(root) {
+			continue
+		}
+		_ = filepath.Walk(root, func(path string, fi os.FileInfo, err error) error {
+			if err != nil {
+				log.Printf("can't stat file %s: %v\n", path, err)
+				return nil
+			}
+			if !fi.IsDir() {
+				return nil
+			}
+			if strings.HasPrefix(fi.Name(), ".") || strings.HasPrefix(fi.Name(), "_") || fi.Name() == "testdata" {
+				return filepath.SkipDir
+			}
+			importPath, err := filepath.Rel(root, path)
+			if err != nil {
+				return nil
+			}
+			importPathFound := gist7480523.NewImportPathFound(importPath, gopathEntry)
+			if goPackage := gist7480523.GoPackageFromImportPathFound(importPathFound); goPackage != nil {
+				out <- importPathFound
+			}
+			return nil
+		})
+	}
+	close(out)
+}
+
+func getGoPackagesC(out chan<- gist7480523.ImportPathFound) {
+	gopathEntries := filepath.SplitList(build.Default.GOPATH)
+	for _, gopathEntry := range gopathEntries {
+		root := filepath.Join(gopathEntry, "src")
+		if !isDir(root) {
+			continue
+		}
+		_ = filepath.Walk(root, func(path string, fi os.FileInfo, err error) error {
+			if err != nil {
+				log.Printf("can't stat file %s: %v\n", path, err)
+				return nil
+			}
+			if !fi.IsDir() {
+				return nil
+			}
+			if strings.HasPrefix(fi.Name(), ".") || strings.HasPrefix(fi.Name(), "_") || fi.Name() == "testdata" {
+				return filepath.SkipDir
+			}
+			bpkg, err := gist5504644.BuildPackageFromSrcDir(path)
+			if err != nil {
+				return nil
+			}
+			/*if bpkg.Goroot {
+				return nil
+			}*/
+			out <- gist7480523.NewImportPathFound(bpkg.ImportPath, bpkg.Root)
+			return nil
+		})
+	}
+	close(out)
+}

--- a/pkg/gist8018045/main.go
+++ b/pkg/gist8018045/main.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/shurcooL/Conception-go/pkg/gist7480523"
 	"github.com/shurcooL/go/gists/gist5504644"
-	"github.com/shurcooL/go/gists/gist7480523"
 )
 
 // GetGoPackages gets all local Go packages (from GOROOT and all GOPATH workspaces).

--- a/pkg/gist8018045/main_test.go
+++ b/pkg/gist8018045/main_test.go
@@ -1,0 +1,20 @@
+package gist8018045
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/shurcooL/go/gists/gist7480523"
+)
+
+func ExampleGetGoPackages() {
+	started := time.Now()
+
+	out := make(chan *gist7480523.GoPackage)
+	go GetGoPackages(out)
+	for goPackage := range out {
+		fmt.Println(goPackage.Bpkg.ImportPath)
+	}
+
+	fmt.Println("time taken:", time.Since(started).Seconds()*1000, "ms")
+}

--- a/pkg/gist8018045/main_test.go
+++ b/pkg/gist8018045/main_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/shurcooL/go/gists/gist7480523"
+	"github.com/shurcooL/Conception-go/pkg/gist7480523"
 )
 
 func ExampleGetGoPackages() {

--- a/pkg/legacyvcs/git.go
+++ b/pkg/legacyvcs/git.go
@@ -1,0 +1,120 @@
+package vcs
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/shurcooL/go/osutil"
+	"github.com/shurcooL/go/trim"
+)
+
+type gitVcs struct {
+	commonVcs
+}
+
+func (this *gitVcs) Type() Type { return Git }
+
+func (this *gitVcs) GetStatus() string {
+	cmd := exec.Command("git", "status", "--porcelain")
+	cmd.Dir = this.rootPath
+
+	if out, err := cmd.Output(); err == nil {
+		return string(out)
+	} else {
+		return ""
+	}
+}
+
+func (this *gitVcs) GetStash() string {
+	cmd := exec.Command("git", "stash", "list")
+	cmd.Dir = this.rootPath
+
+	if out, err := cmd.Output(); err == nil {
+		return string(out)
+	} else {
+		return ""
+	}
+}
+
+func (this *gitVcs) GetRemote() string {
+	cmd := exec.Command("git", "ls-remote", "--get-url", "origin")
+	cmd.Dir = this.rootPath
+
+	if out, err := cmd.Output(); err == nil {
+		return trim.LastNewline(string(out))
+	} else {
+		return ""
+	}
+}
+
+func (this *gitVcs) GetDefaultBranch() string {
+	return "master"
+}
+
+func (this *gitVcs) GetLocalBranch() string {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.Dir = this.rootPath
+
+	if out, err := cmd.Output(); err == nil {
+		// Since rev-parse is considered porcelain and may change, need to error-check its output.
+		return trim.LastNewline(string(out))
+	} else {
+		return ""
+	}
+}
+
+// Length of a git revision hash.
+const gitRevisionLength = 40
+
+func (this *gitVcs) GetLocalRev() string {
+	cmd := exec.Command("git", "rev-parse", this.GetDefaultBranch())
+	cmd.Dir = this.rootPath
+
+	if out, err := cmd.Output(); err == nil && len(out) >= gitRevisionLength {
+		return string(out[:gitRevisionLength])
+	} else {
+		return ""
+	}
+}
+
+func (this *gitVcs) GetRemoteRev() string {
+	// true here is not a boolean value, but a command /bin/true that will make git think it asked for a password,
+	// and prevent potential interactive password prompts (opting to return failure exit code instead).
+	cmd := exec.Command("git", "-c", "core.askpass=true", "ls-remote", "--heads", "origin", this.GetDefaultBranch())
+	cmd.Dir = this.rootPath
+	env := osutil.Environ(os.Environ())
+	env.Set("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=yes") // Default for StrictHostKeyChecking is "ask", which we don't want since this is non-interactive and we prefer to fail than block asking for user input.
+	cmd.Env = env
+
+	if out, err := cmd.Output(); err == nil && len(out) >= gitRevisionLength {
+		return string(out[:gitRevisionLength])
+	} else {
+		return ""
+	}
+}
+
+func (this *gitVcs) IsContained(rev string) bool {
+	cmd := exec.Command("git", "branch", "--list", "--contains", rev, this.GetDefaultBranch())
+	cmd.Dir = this.rootPath
+
+	if out, err := cmd.Output(); err == nil {
+		if len(out) >= 2 && trim.LastNewline(string(out[2:])) == this.GetDefaultBranch() {
+			return true
+		}
+	}
+	return false
+}
+
+// ---
+
+func getGitRepoRoot(path string) (isGitRepo bool, rootPath string) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd.Dir = path
+
+	if out, err := cmd.Output(); err == nil {
+		// Since rev-parse is considered porcelain and may change, need to error-check its output
+		return true, trim.LastNewline(string(out))
+	} else {
+		return false, ""
+	}
+}

--- a/pkg/legacyvcs/git.go
+++ b/pkg/legacyvcs/git.go
@@ -1,4 +1,4 @@
-package vcs
+package legacyvcs
 
 import (
 	"os"

--- a/pkg/legacyvcs/hg.go
+++ b/pkg/legacyvcs/hg.go
@@ -1,0 +1,100 @@
+package vcs
+
+import (
+	"os/exec"
+	"strings"
+
+	trim "github.com/shurcooL/go/trim"
+)
+
+func getHgRepoRoot(path string) (isHgRepo bool, rootPath string) {
+	cmd := exec.Command("hg", "root")
+	cmd.Dir = path
+
+	if out, err := cmd.Output(); err == nil {
+		return true, trim.LastNewline(string(out))
+	} else {
+		return false, ""
+	}
+}
+
+type hgVcs struct {
+	commonVcs
+}
+
+func (this *hgVcs) Type() Type { return Hg }
+
+func (this *hgVcs) GetStatus() string {
+	cmd := exec.Command("hg", "status")
+	cmd.Dir = this.rootPath
+
+	if out, err := cmd.Output(); err == nil {
+		return string(out)
+	} else {
+		return ""
+	}
+}
+
+func (this *hgVcs) GetStash() string {
+	// TODO: Does Mercurial have stashes? Figure it out, add support, etc.
+	return ""
+}
+
+func (this *hgVcs) GetRemote() string {
+	cmd := exec.Command("hg", "paths", "default")
+	cmd.Dir = this.rootPath
+
+	if out, err := cmd.Output(); err == nil {
+		return trim.LastNewline(string(out))
+	} else {
+		return ""
+	}
+}
+
+func (this *hgVcs) GetDefaultBranch() string {
+	return "default"
+}
+
+func (this *hgVcs) GetLocalBranch() string {
+	cmd := exec.Command("hg", "branch")
+	cmd.Dir = this.rootPath
+
+	if out, err := cmd.Output(); err == nil {
+		return trim.LastNewline(string(out))
+	} else {
+		return ""
+	}
+}
+
+// Length of a Mercurial revision hash.
+const hgRevisionLength = 40
+
+func (this *hgVcs) GetLocalRev() string {
+	// Alternative: hg parent --template '{node}'
+	cmd := exec.Command("hg", "--debug", "identify", "-i", "--rev", this.GetDefaultBranch())
+	cmd.Dir = this.rootPath
+
+	if out, err := cmd.Output(); err == nil && len(out) >= hgRevisionLength {
+		return string(out[:hgRevisionLength])
+	} else {
+		return ""
+	}
+}
+
+func (this *hgVcs) GetRemoteRev() string {
+	// TODO: Make this more robust and proper, etc.
+	cmd := exec.Command("hg", "--debug", "identify", "-i", "--rev", this.GetDefaultBranch(), "default")
+	cmd.Dir = this.rootPath
+
+	if out, err := cmd.Output(); err == nil {
+		// Get the last line of output.
+		lines := strings.Split(trim.LastNewline(string(out)), "\n") // Always returns at least 1 element.
+		return lines[len(lines)-1]
+	}
+	return ""
+}
+
+func (this *hgVcs) IsContained(rev string) bool {
+	// TODO.
+	return false
+}

--- a/pkg/legacyvcs/hg.go
+++ b/pkg/legacyvcs/hg.go
@@ -1,4 +1,4 @@
-package vcs
+package legacyvcs
 
 import (
 	"os/exec"

--- a/pkg/legacyvcs/vcs.go
+++ b/pkg/legacyvcs/vcs.go
@@ -1,0 +1,109 @@
+// Package vcs allows getting status of a repo under vcs.
+package vcs
+
+import "os/exec"
+
+type Type uint8
+
+const (
+	Git Type = iota
+	Hg
+)
+
+// VcsType returns a vcsType string compatible with sourcegraph.com/sourcegraph/go-vcs notation.
+func (t Type) VcsType() (vcsType string) {
+	switch t {
+	case Git:
+		return "git"
+	case Hg:
+		return "hg"
+	default:
+		panic("bad vcs.Type")
+	}
+}
+
+type Vcs interface {
+	RootPath() string // Returns the full path to the root of the repo.
+	Type() Type       // Returns the type of vcs implementation.
+
+	GetStatus() string // Returns empty string if no outstanding status.
+	GetStash() string  // Returns empty string if no stash.
+
+	GetRemote() string // Get primary remote repository url.
+
+	GetDefaultBranch() string // Get default branch name for this vcs.
+	GetLocalBranch() string   // Get currently checked out local branch name.
+
+	GetLocalRev() string  // Get current local revision of default branch.
+	GetRemoteRev() string // Get latest remote revision of default branch.
+
+	// Returns true if given commit is contained in the default local branch.
+	IsContained(rev string) bool
+}
+
+type commonVcs struct {
+	rootPath string
+}
+
+func (this *commonVcs) RootPath() string {
+	return this.rootPath
+}
+
+// New returns a new Vcs if path is under version control, otherwise nil.
+// It should be a valid path.
+func New(path string) Vcs {
+	// TODO: Try to figure out vcs provider with a more constant-time operation.
+	// TODO: Potentially check in parallel.
+	for _, vcsProvider := range vcsProviders {
+		if vcs := vcsProvider(path); vcs != nil {
+			return vcs
+		}
+	}
+
+	return nil
+}
+
+// Experimental, NewFromType returns a Vcs repository of the specified type without a local representation.
+// Operations that require a local repository will fail.
+func NewFromType(t Type) Vcs {
+	switch t {
+	case Git:
+		return &gitVcs{}
+	case Hg:
+		return &hgVcs{}
+	default:
+		panic("bad vcs.Type")
+	}
+}
+
+type vcsProvider func(path string) Vcs
+
+var vcsProviders []vcsProvider
+
+func addVcsProvider(s vcsProvider) {
+	vcsProviders = append(vcsProviders, s)
+}
+
+func init() {
+	// As an optimization, add Vcs providers sorted by the most likely first.
+
+	// git.
+	if _, err := exec.LookPath("git"); err == nil {
+		addVcsProvider(func(path string) Vcs {
+			if isRepo, rootPath := getGitRepoRoot(path); isRepo {
+				return &gitVcs{commonVcs{rootPath: rootPath}}
+			}
+			return nil
+		})
+	}
+
+	// hg.
+	if _, err := exec.LookPath("hg"); err == nil {
+		addVcsProvider(func(path string) Vcs {
+			if isRepo, rootPath := getHgRepoRoot(path); isRepo {
+				return &hgVcs{commonVcs{rootPath: rootPath}}
+			}
+			return nil
+		})
+	}
+}

--- a/pkg/legacyvcs/vcs.go
+++ b/pkg/legacyvcs/vcs.go
@@ -1,5 +1,10 @@
 // Package vcs allows getting status of a repo under vcs.
-package vcs
+//
+// This package has been superseded by a better version at
+// github.com/shurcooL/vcsstate. That package should be used.
+// This legacy version is copied into Conception-go repo so that
+// it can continue to build without doing the work of refactoring.
+package legacyvcs
 
 import "os/exec"
 

--- a/pkg/u6/main.go
+++ b/pkg/u6/main.go
@@ -7,11 +7,11 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/shurcooL/go/exp/13"
-	"github.com/shurcooL/go/gists/gist7480523"
+	"github.com/shurcooL/Conception-go/pkg/exp13"
+	"github.com/shurcooL/Conception-go/pkg/gist7480523"
+	"github.com/shurcooL/Conception-go/pkg/legacyvcs"
 	"github.com/shurcooL/go/pipe_util"
 	"github.com/shurcooL/go/trim"
-	"github.com/shurcooL/go/vcs"
 	"gopkg.in/pipe.v2"
 )
 
@@ -22,7 +22,7 @@ func GoPackageWorkingDiff(goPackage *gist7480523.GoPackage) string {
 	// git diff
 	if goPackage.Dir.Repo.VcsLocal.Status != "" {
 		switch goPackage.Dir.Repo.Vcs.Type() {
-		case vcs.Git:
+		case legacyvcs.Git:
 			newFileDiff := func(line []byte) []byte {
 				cmd := exec.Command("git", "diff", "--no-ext-diff", "--", "/dev/null", trim.LastNewline(string(line)))
 				cmd.Dir = goPackage.Dir.Repo.Vcs.RootPath()
@@ -61,7 +61,7 @@ func GoPackageWorkingDiff(goPackage *gist7480523.GoPackage) string {
 func GoPackageWorkingDiffMaster(goPackage *gist7480523.GoPackage) string {
 	if goPackage.Dir.Repo.VcsLocal.Status != "" || goPackage.Dir.Repo.VcsLocal.LocalBranch != goPackage.Dir.Repo.Vcs.GetDefaultBranch() {
 		switch goPackage.Dir.Repo.Vcs.Type() {
-		case vcs.Git:
+		case legacyvcs.Git:
 			newFileDiff := func(line []byte) []byte {
 				cmd := exec.Command("git", "diff", "--no-ext-diff", "--", "/dev/null", trim.LastNewline(string(line)))
 				cmd.Dir = goPackage.Dir.Repo.Vcs.RootPath()
@@ -110,7 +110,7 @@ func (bo *BranchesOptions) defaults() {
 func Branches(repo *exp13.VcsState, opt BranchesOptions) string {
 	opt.defaults()
 	switch repo.Vcs.Type() {
-	case vcs.Git:
+	case legacyvcs.Git:
 		branchInfo := func(line []byte) []byte {
 			branch := trim.LastNewline(string(line))
 			branchDisplay := branch
@@ -186,7 +186,7 @@ func branchRemoteInfo(repo *exp13.VcsState) func(line []byte) []byte {
 // BranchesRemote returns a Markdown table of branches with ahead/behind information relative to remote.
 func BranchesRemote(repo *exp13.VcsState) string {
 	switch repo.Vcs.Type() {
-	case vcs.Git:
+	case legacyvcs.Git:
 		p := pipe.Script(
 			pipe.Println("Branch | Remote | Behind | Ahead"),
 			pipe.Println("-------|--------|-------:|:-----"),
@@ -209,7 +209,7 @@ func BranchesRemote(repo *exp13.VcsState) string {
 // BranchesRemoteCustom returns a Markdown table of branches with ahead/behind information relative to the specified remote.
 func BranchesRemoteCustom(repo *exp13.VcsState, remote string) string {
 	switch repo.Vcs.Type() {
-	case vcs.Git:
+	case legacyvcs.Git:
 		p := pipe.Script(
 			pipe.Println("Branch | Remote | Behind | Ahead"),
 			pipe.Println("-------|--------|-------:|:-----"),

--- a/pkg/u6/main.go
+++ b/pkg/u6/main.go
@@ -1,0 +1,230 @@
+// Package u6 implements funcs for comparing working directories and branches in vcs repositories.
+package u6
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+
+	"github.com/shurcooL/go/exp/13"
+	"github.com/shurcooL/go/gists/gist7480523"
+	"github.com/shurcooL/go/pipe_util"
+	"github.com/shurcooL/go/trim"
+	"github.com/shurcooL/go/vcs"
+	"gopkg.in/pipe.v2"
+)
+
+// GoPackageWorkingDiff shows the difference between the working directory and the most recent commit.
+// Precondition is that goPackage.Dir.Repo is not nil, and VcsLocal is updated.
+// TODO: Support for non-git.
+func GoPackageWorkingDiff(goPackage *gist7480523.GoPackage) string {
+	// git diff
+	if goPackage.Dir.Repo.VcsLocal.Status != "" {
+		switch goPackage.Dir.Repo.Vcs.Type() {
+		case vcs.Git:
+			newFileDiff := func(line []byte) []byte {
+				cmd := exec.Command("git", "diff", "--no-ext-diff", "--", "/dev/null", trim.LastNewline(string(line)))
+				cmd.Dir = goPackage.Dir.Repo.Vcs.RootPath()
+				out, err := cmd.Output()
+				if len(out) > 0 {
+					// diff exits with a non-zero status when the files don't match.
+					// Ignore that failure as long as we get output.
+					err = nil
+				}
+				if err != nil {
+					return []byte(err.Error())
+				}
+				return out
+			}
+
+			p := pipe.Script(
+				pipe.Exec("git", "diff", "--no-ext-diff", "--find-renames", "HEAD"),
+				pipe.Line(
+					pipe.Exec("git", "ls-files", "--others", "--exclude-standard"),
+					pipe.Replace(newFileDiff),
+				),
+			)
+
+			out, err := pipe_util.OutputDir(p, goPackage.Dir.Repo.Vcs.RootPath())
+			if err != nil {
+				return err.Error()
+			}
+			return string(out)
+		}
+	}
+	return ""
+}
+
+// GoPackageWorkingDiffMaster shows the difference between the working directory and master branch.
+// Precondition is that goPackage.Dir.Repo is not nil, and VcsLocal is updated.
+func GoPackageWorkingDiffMaster(goPackage *gist7480523.GoPackage) string {
+	if goPackage.Dir.Repo.VcsLocal.Status != "" || goPackage.Dir.Repo.VcsLocal.LocalBranch != goPackage.Dir.Repo.Vcs.GetDefaultBranch() {
+		switch goPackage.Dir.Repo.Vcs.Type() {
+		case vcs.Git:
+			newFileDiff := func(line []byte) []byte {
+				cmd := exec.Command("git", "diff", "--no-ext-diff", "--", "/dev/null", trim.LastNewline(string(line)))
+				cmd.Dir = goPackage.Dir.Repo.Vcs.RootPath()
+				out, err := cmd.Output()
+				if len(out) > 0 {
+					// diff exits with a non-zero status when the files don't match.
+					// Ignore that failure as long as we get output.
+					err = nil
+				}
+				if err != nil {
+					return []byte(err.Error())
+				}
+				return out
+			}
+
+			p := pipe.Script(
+				pipe.Exec("git", "diff", "--no-ext-diff", "--find-renames", "master"),
+				pipe.Line(
+					pipe.Exec("git", "ls-files", "--others", "--exclude-standard"),
+					pipe.Replace(newFileDiff),
+				),
+			)
+
+			out, err := pipe_util.OutputDir(p, goPackage.Dir.Repo.Vcs.RootPath())
+			if err != nil {
+				return err.Error()
+			}
+			return string(out)
+		}
+	}
+	return ""
+}
+
+// BranchesOptions are options for Branches.
+type BranchesOptions struct {
+	Base string // Base branch to compare against (if blank, defaults to "master").
+}
+
+func (bo *BranchesOptions) defaults() {
+	if bo.Base == "" {
+		bo.Base = "master"
+	}
+}
+
+// Branches returns a Markdown table of branches with ahead/behind information relative to master branch.
+func Branches(repo *exp13.VcsState, opt BranchesOptions) string {
+	opt.defaults()
+	switch repo.Vcs.Type() {
+	case vcs.Git:
+		branchInfo := func(line []byte) []byte {
+			branch := trim.LastNewline(string(line))
+			branchDisplay := branch
+			if branch == repo.VcsLocal.LocalBranch {
+				branchDisplay = "**" + branch + "**"
+			}
+
+			cmd := exec.Command("git", "rev-list", "--count", "--left-right", opt.Base+"..."+branch)
+			cmd.Dir = repo.Vcs.RootPath()
+			out, err := cmd.Output()
+			if err != nil {
+				log.Printf("error running %v: %v\n", cmd.Args, err)
+				return []byte(fmt.Sprintf("%s | ? | ?\n", branchDisplay))
+			}
+
+			behindAhead := strings.Split(trim.LastNewline(string(out)), "\t")
+			return []byte(fmt.Sprintf("%s | %s | %s\n", branchDisplay, behindAhead[0], behindAhead[1]))
+		}
+
+		p := pipe.Script(
+			pipe.Println("Branch | Behind | Ahead"),
+			pipe.Println("-------|-------:|:-----"),
+			pipe.Line(
+				pipe.Exec("git", "for-each-ref", "--format=%(refname:short)", "refs/heads"),
+				pipe.Replace(branchInfo),
+			),
+		)
+
+		out, err := pipe_util.OutputDir(p, repo.Vcs.RootPath())
+		if err != nil {
+			return err.Error()
+		}
+		return string(out)
+	default:
+		return ""
+	}
+}
+
+// Input is a line containing tab-separated local branch and remote branch.
+// For example, "master\torigin/master".
+func branchRemoteInfo(repo *exp13.VcsState) func(line []byte) []byte {
+	return func(line []byte) []byte {
+		branchRemote := strings.Split(trim.LastNewline(string(line)), "\t")
+		if len(branchRemote) != 2 {
+			return []byte("error: len(branchRemote) != 2")
+		}
+
+		branch := branchRemote[0]
+		branchDisplay := branch
+		if branch == repo.VcsLocal.LocalBranch {
+			branchDisplay = "**" + branch + "**"
+		}
+
+		remote := branchRemote[1]
+		if remote == "" {
+			return []byte(fmt.Sprintf("%s | | | \n", branchDisplay))
+		}
+
+		cmd := exec.Command("git", "rev-list", "--count", "--left-right", remote+"..."+branch)
+		cmd.Dir = repo.Vcs.RootPath()
+		out, err := cmd.Output()
+		if err != nil {
+			// This usually happens when the remote branch is gone.
+			remoteDisplay := "~~" + remote + "~~"
+			return []byte(fmt.Sprintf("%s | %s | | \n", branchDisplay, remoteDisplay))
+		}
+
+		behindAhead := strings.Split(trim.LastNewline(string(out)), "\t")
+		return []byte(fmt.Sprintf("%s | %s | %s | %s\n", branchDisplay, remote, behindAhead[0], behindAhead[1]))
+	}
+}
+
+// BranchesRemote returns a Markdown table of branches with ahead/behind information relative to remote.
+func BranchesRemote(repo *exp13.VcsState) string {
+	switch repo.Vcs.Type() {
+	case vcs.Git:
+		p := pipe.Script(
+			pipe.Println("Branch | Remote | Behind | Ahead"),
+			pipe.Println("-------|--------|-------:|:-----"),
+			pipe.Line(
+				pipe.Exec("git", "for-each-ref", "--format=%(refname:short)\t%(upstream:short)", "refs/heads"),
+				pipe.Replace(branchRemoteInfo(repo)),
+			),
+		)
+
+		out, err := pipe_util.OutputDir(p, repo.Vcs.RootPath())
+		if err != nil {
+			return err.Error()
+		}
+		return string(out)
+	default:
+		return ""
+	}
+}
+
+// BranchesRemoteCustom returns a Markdown table of branches with ahead/behind information relative to the specified remote.
+func BranchesRemoteCustom(repo *exp13.VcsState, remote string) string {
+	switch repo.Vcs.Type() {
+	case vcs.Git:
+		p := pipe.Script(
+			pipe.Println("Branch | Remote | Behind | Ahead"),
+			pipe.Println("-------|--------|-------:|:-----"),
+			pipe.Line(
+				pipe.Exec("git", "for-each-ref", "--format=%(refname:short)\t"+remote+"/%(refname:short)", "refs/heads"),
+				pipe.Replace(branchRemoteInfo(repo)),
+			),
+		)
+
+		out, err := pipe_util.OutputDir(p, repo.Vcs.RootPath())
+		if err != nil {
+			return err.Error()
+		}
+		return string(out)
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
That package has been removed upstream, because it migrated to a better API and cleaner code at [`github.com/shurcooL/vcsstate`](https://github.com/shurcooL/vcsstate).

However, Conception-go is not being updated to new API now. However, I want it to continue to build, so do that by copying removed legacy package into this repository.

Helps shurcooL/go#18.